### PR TITLE
New/interpals text - tidies code, removes timestamp

### DIFF
--- a/datasources/interpals-text/manifest.json
+++ b/datasources/interpals-text/manifest.json
@@ -2,6 +2,6 @@
   "name": "interpals-text",
   "author": "Rory",
   "description": "This DataSource tracks every message the user sends on interpals.net along with the timestmap",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "sites": [".*\\.interpals.net/pm.php?.*"]
 }

--- a/datasources/interpals-text/plugin.js
+++ b/datasources/interpals-text/plugin.js
@@ -1,4 +1,4 @@
-const registerEventsHandler = function(doc, mc) {
+const registerEventsHandler = function(mc) {
   let textarea = $('#message');
   let sendButton = $("#msg_submit");
 
@@ -10,13 +10,11 @@ const registerEventsHandler = function(doc, mc) {
 const sendDatapoint = function(message, mc) {
   let datapoint = {};
   datapoint['message'] = message;
-  datapoint['timestamp'] = Date.now();
-  console.log(datapoint);
 
   mc.sendDatapoint(datapoint);
 }
 
 function initDataSource(metroClient) {
-  registerEventsHandler(document, metroClient);
+  registerEventsHandler(metroClient);
   console.log("Loaded Interpals-Text DataSource");
 }

--- a/datasources/interpals-text/schema.json
+++ b/datasources/interpals-text/schema.json
@@ -1,4 +1,3 @@
 {
-  "message": "example message.,-=+?![]()",
-  "timestamp": "1522167313180"
+  "message": "example message.,-=+?![]()"
 }


### PR DESCRIPTION
Metro automatically includes the timestamp, so we don't need to capture it inside the DataSource anymore.

Since jQuery is being used to select the DOM elements, we don't need to pass a reference to the `document` around.